### PR TITLE
[🪿 M1]  메인 페이지 라우팅 및 동물 목록 렌더링, 상세 페이지 연결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.24.1"
+        "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
         "@types/react": "^18.3.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.24.1"
+    "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,9 @@
 import { useState } from "react";
 import "./App.css";
+import { Route, Routes } from "react-router-dom";
+import Main from "./page/Main";
+import Detail from "./page/Detail";
+import Search from "./page/Search";
 
 function App() {
   return (
@@ -7,6 +11,11 @@ function App() {
       <header>
         <h1>💚 동물 조아 💚</h1>
       </header>
+      <Routes>
+        <Route path="/" element={<Main />}></Route>
+        <Route path="/detail" element={<Detail />}></Route>
+        <Route path="/search" element={<Search />}></Route>
+      </Routes>
       <footer>all rights reserved to OZ</footer>
     </>
   );

--- a/src/page/Detail.jsx
+++ b/src/page/Detail.jsx
@@ -1,0 +1,5 @@
+function Detail() {
+  return <>상제 정보 페이지</>;
+}
+
+export default Detail;

--- a/src/page/Main.jsx
+++ b/src/page/Main.jsx
@@ -1,0 +1,5 @@
+function Main() {
+  return <>메인 페이지</>;
+}
+
+export default Main;

--- a/src/page/Main.jsx
+++ b/src/page/Main.jsx
@@ -1,5 +1,16 @@
+import { data } from "../assets/data/data";
+
 function Main() {
-  return <>메인 페이지</>;
+  return (
+    <ul>
+      {data.map((el) => (
+        <li key={el.id}>
+          <img src={el.img} alt={el.name} />
+          <div>{el.name}</div>
+        </li>
+      ))}
+    </ul>
+  );
 }
 
 export default Main;

--- a/src/page/Main.jsx
+++ b/src/page/Main.jsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { data } from "../assets/data/data";
 
 function Main() {
@@ -5,8 +6,10 @@ function Main() {
     <ul>
       {data.map((el) => (
         <li key={el.id}>
-          <img src={el.img} alt={el.name} />
-          <div>{el.name}</div>
+          <Link to={`/detail/${el.id}`}>
+            <img src={el.img} alt={el.name} />
+            <div>{el.name}</div>
+          </Link>
         </li>
       ))}
     </ul>

--- a/src/page/Search.jsx
+++ b/src/page/Search.jsx
@@ -1,0 +1,5 @@
+function Search() {
+  return <>검색 결과 페이지</>;
+}
+
+export default Search;


### PR DESCRIPTION
#1 
## 📝 Assignment

- Branch: feature/m1
- Subject: 메인 페이지 라우팅 및 데이터 렌더링, 상세 페이지 연결

<br>

## 🧾 Commit Messages

- feat(router): set up basic routing with Main, Detail, Search page (#1)
- feat(main): render animal list from data.js (#1)
- feat(main): navigate to /detail/:id when animal card is clicked (#1)

<br>

## 📌 Notes

### React Router 기본 구조 이해
- `BrowserRouter`로 앱 전체 라우팅 컨텍스트 제공
- `Routes`와 `Route`로 경로별 컴포넌트 매핑
- `Link`를 사용해 페이지 새로고침 없이 경로 이동 구현

### data.js 데이터 렌더링
- `map()`을 이용해 배열 데이터를 반복 렌더링
- `key` 속성으로 각 항목의 고유성을 React에 전달

### 동물 카드 클릭 → 상세 페이지 이동
- `Link`에 `/detail/${id}` 경로를 지정해 카드별 상세 페이지 연결

### 기타
- 컴포넌트를 페이지 단위로 분리(Main, Detail, Search)

<br>

## 📚 Reference (선택)

- [링크/문서/블로그]

---

💡 이 브랜치는 학습용이며, 메인에는 병합하지 않습니다.