### PR TITLE
[🪿 M3] useSearchParams 기반 검색 페이지 구현 및 korean-regexp 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vite-project",
       "version": "0.0.0",
       "dependencies": {
+        "korean-regexp": "^1.0.13",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.30.1"
@@ -3339,6 +3340,12 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/korean-regexp": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/korean-regexp/-/korean-regexp-1.0.13.tgz",
+      "integrity": "sha512-U+dULDtJSZnzbV13hg2EjTaoKqXRqucDArmzb/3KX+DyP1lAzEXoTvTK992m7cmOTAJ2xrv4RueXlMBKdhJ1bQ==",
+      "license": "MIT"
     },
     "node_modules/levn": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "korean-regexp": "^1.0.13",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.30.1"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,15 +1,20 @@
 import { useState } from "react";
 import "./App.css";
-import { Route, Routes } from "react-router-dom";
+import { Route, Routes, useNavigate } from "react-router-dom";
 import Main from "./page/Main";
 import Detail from "./page/Detail";
 import Search from "./page/Search";
 
 function App() {
+  const [inputValue, setInputValue] = useState("");
+  const navigate = useNavigate();
+
   return (
     <>
       <header>
         <h1>💚 동물 조아 💚</h1>
+        <input value={inputValue} onChange={(event) => setInputValue(event.target.value)} />
+        <button onClick={() => navigate(`/search?animal=${inputValue}`)}>검색</button>
       </header>
       <Routes>
         <Route path="/" element={<Main />}></Route>

--- a/src/page/Search.jsx
+++ b/src/page/Search.jsx
@@ -1,5 +1,26 @@
+import { Link, useSearchParams } from "react-router-dom";
+import { data } from "../assets/data/data";
+import { getRegExp } from "korean-regexp";
+
 function Search() {
-  return <>검색 결과 페이지</>;
+  const [searchParams] = useSearchParams();
+  const param = searchParams.get("animal");
+  const reg = getRegExp(param);
+
+  const filteredData = data.filter((el) => el.name.match(reg));
+
+  return (
+    <ul>
+      {filteredData.map((el) => (
+        <li key={el.id}>
+          <Link to={`/detail/${el.id}`}>
+            <img src={el.img} alt={el.name} />
+            <div>{el.name}</div>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
 }
 
 export default Search;


### PR DESCRIPTION
#3 
## 📝 Assignment

- Branch: feature/m3
- Subject:  useSearchParams 기반 검색 페이지 구현 및 korean-regexp 적용

<br>

## 🧾 Commit Messages

- feat(search): add navigation to search page with query parameter using useNavigate
- feat(search): implement query param based filtering with useSearchParams and korean-regexp

<br>

## 📌 Notes

### 검색 페이지 및 기능 구현
- 검색 입력값을 `useNavigate`로 `/search?query=검색어` 경로로 이동
- `useSearchParams()`를 사용해 URL의 query 값을 읽어옴
- `korean-regexp` 라이브러리를 사용해 한글 초성/부분 일치 검색 지원
- `data.js`에서 검색어로 필터링된 결과를 리스트 형태로 렌더링


<br>

## 📚 Reference (선택)

- [korean-regexp](https://www.npmjs.com/package/korean-regexp)

---

💡 이 브랜치는 학습용입니다.