### PR TITLE
[🪿 M5] 검색창 최적화 Debounce vs Throttle 적용 및 비교

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,7 +17,10 @@ function App() {
         <h1>💚 동물 조아 💚</h1>
         <input
           value={inputValue}
-          onChange={(event) => setInputValue(event.target.value)}
+          onChange={(event) => {
+            setInputValue(event.target.value);
+            navigate(`/search?animal=${event.target.value}`);
+          }}
         />
         <button onClick={() => navigate(`/search?animal=${inputValue}`)}>
           검색

--- a/src/page/Search.jsx
+++ b/src/page/Search.jsx
@@ -1,13 +1,62 @@
 import { Link, useSearchParams } from "react-router-dom";
 import { data } from "../assets/data/data";
 import { getRegExp } from "korean-regexp";
+import { useEffect, useState } from "react";
 
+// 기존 방식
+// function Search() {
+//   const [searchParams] = useSearchParams();
+//   const param = searchParams.get("animal");
+//   const reg = getRegExp(param);
+
+//   const filteredData = data.filter((el) => el.name.match(reg));
+
+//   return (
+//     <ul>
+//       {filteredData.map((el) => (
+//         <li key={el.id}>
+//           <Link to={`/detail/${el.id}`}>
+//             <img src={el.img} alt={el.name} />
+//             <div>{el.name}</div>
+//           </Link>
+//         </li>
+//       ))}
+//     </ul>
+//   );
+// }
+
+// debounce 적용 Search 컴포넌트
 function Search() {
   const [searchParams] = useSearchParams();
+  // 화면에 표시할 데이터 상태 (초기값: 전체 data를 보여줌)
+  const [filteredData, setFilteredData] = useState(data);
+  // URL 쿼리스트링에서 animal 파라미터 추출
   const param = searchParams.get("animal");
-  const reg = getRegExp(param);
 
-  const filteredData = data.filter((el) => el.name.match(reg));
+  useEffect(() => {
+    // 검색어가 없으면 전체 데이터 표시
+    if (!param) {
+      setFilteredData(data);
+      return;
+    }
+
+    // 한글 초성/중성 검색을 위한 정규식 생성
+    const reg = getRegExp(param);
+
+    // debounce: 1초 대기 후 필터링 실행
+    // 사용자가 타이핑을 멈춘 후 1초 뒤에 검색이 실행된다.
+    const debounceTimer = setTimeout(() => {
+      // 정규식과 매칭되는 데이터만 필터링
+      const newFilteredData = data.filter((el) => el.name.match(reg));
+      setFilteredData(newFilteredData);
+    }, 1000);
+
+    // cleanup 함수: 컴포넌트 언마운트 또는 param 변경 시 실행
+    // 이전 타이머를 취소하여 불필요한 검색 방지
+    // 예: "강아" 입력 중 "강아지"로 바뀌면 "강아"의 타이머는 취소된다.
+    return () => clearTimeout(debounceTimer);
+  }, [param]);
+  // param이 변경될 때마다 effect 재실행
 
   return (
     <ul>

--- a/src/page/Search.jsx
+++ b/src/page/Search.jsx
@@ -1,7 +1,7 @@
 import { Link, useSearchParams } from "react-router-dom";
 import { data } from "../assets/data/data";
 import { getRegExp } from "korean-regexp";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 // 기존 방식
 // function Search() {
@@ -26,12 +26,63 @@ import { useEffect, useState } from "react";
 // }
 
 // debounce 적용 Search 컴포넌트
+// function Search() {
+//   const [searchParams] = useSearchParams();
+//   // 화면에 표시할 데이터 상태 (초기값: 전체 data를 보여줌)
+//   const [filteredData, setFilteredData] = useState(data);
+//   // URL 쿼리스트링에서 animal 파라미터 추출
+//   const param = searchParams.get("animal");
+
+//   useEffect(() => {
+//     // 검색어가 없으면 전체 데이터 표시
+//     if (!param) {
+//       setFilteredData(data);
+//       return;
+//     }
+
+//     // 한글 초성/중성 검색을 위한 정규식 생성
+//     const reg = getRegExp(param);
+
+//     // debounce: 1초 대기 후 필터링 실행
+//     // 사용자가 타이핑을 멈춘 후 1초 뒤에 검색이 실행된다.
+//     const debounceTimer = setTimeout(() => {
+//       // 정규식과 매칭되는 데이터만 필터링
+//       const newFilteredData = data.filter((el) => el.name.match(reg));
+//       setFilteredData(newFilteredData);
+//     }, 1000);
+
+//     // cleanup 함수: 컴포넌트 언마운트 또는 param 변경 시 실행
+//     // 이전 타이머를 취소하여 불필요한 검색 방지
+//     // 예: "강아" 입력 중 "강아지"로 바뀌면 "강아"의 타이머는 취소된다.
+//     return () => clearTimeout(debounceTimer);
+//   }, [param]);
+//   // param이 변경될 때마다 effect 재실행
+
+//   return (
+//     <ul>
+//       {filteredData.map((el) => (
+//         <li key={el.id}>
+//           <Link to={`/detail/${el.id}`}>
+//             <img src={el.img} alt={el.name} />
+//             <div>{el.name}</div>
+//           </Link>
+//         </li>
+//       ))}
+//     </ul>
+//   );
+// }
+
+// throttle 적용 Search 컴포넌트
 function Search() {
   const [searchParams] = useSearchParams();
   // 화면에 표시할 데이터 상태 (초기값: 전체 data를 보여줌)
   const [filteredData, setFilteredData] = useState(data);
   // URL 쿼리스트링에서 animal 파라미터 추출
   const param = searchParams.get("animal");
+
+  // throttle 제어용 ref들
+  const lastExecutedTime = useRef(0); // 마지막으로 실행된 시각 저장 (밀리초)
+  const throttleTimer = useRef(null); // 예약된 setTimeout ID 저장
 
   useEffect(() => {
     // 검색어가 없으면 전체 데이터 표시
@@ -43,20 +94,47 @@ function Search() {
     // 한글 초성/중성 검색을 위한 정규식 생성
     const reg = getRegExp(param);
 
-    // debounce: 1초 대기 후 필터링 실행
-    // 사용자가 타이핑을 멈춘 후 1초 뒤에 검색이 실행된다.
-    const debounceTimer = setTimeout(() => {
-      // 정규식과 매칭되는 데이터만 필터링
+    // 현재 시각
+    const now = Date.now();
+
+    // 마지막 실행으로부터 경과한 시간
+    const timeSinceLastExecution = now - lastExecutedTime.current;
+
+    // 검색 실행 함수
+    const executeSearch = () => {
       const newFilteredData = data.filter((el) => el.name.match(reg));
       setFilteredData(newFilteredData);
-    }, 1000);
+      lastExecutedTime.current = Date.now(); // 실행 시각 업데이트
+    };
 
-    // cleanup 함수: 컴포넌트 언마운트 또는 param 변경 시 실행
-    // 이전 타이머를 취소하여 불필요한 검색 방지
-    // 예: "강아" 입력 중 "강아지"로 바뀌면 "강아"의 타이머는 취소된다.
-    return () => clearTimeout(debounceTimer);
-  }, [param]);
-  // param이 변경될 때마다 effect 재실행
+    // Throttle 로직
+    if (timeSinceLastExecution >= 1000) {
+      // Case 1: 마지막 실행으로부터 1초 이상 지났으면 즉시 실행
+      executeSearch();
+    } else {
+      // Case 2: 1초가 안 지났으면 남은 시간만큼 대기 후 실행
+
+      // 기존에 예약된 타이머가 있다면 취소 (최신 입력만 반영하기 위해)
+      if (throttleTimer.current) {
+        clearTimeout(throttleTimer.current);
+      }
+
+      // 아직 남아있는 시간 계산 (1초 - 경과 시간)
+      const remainingTime = 1000 - timeSinceLastExecution;
+
+      // 남은 시간이 지나면 실행 예약
+      throttleTimer.current = setTimeout(() => {
+        executeSearch();
+        throttleTimer.current = null; // 타이머 초기화
+      }, remainingTime);
+    }
+    // Cleanup: 다음 useEffect 실행 전 or 컴포넌트 언마운트 시 타이머 정리
+    return () => {
+      if (throttleTimer.current) {
+        clearTimeout(throttleTimer.current);
+      }
+    };
+  }, [param]); // param이 바뀔 때마다 이 로직이 실행됨
 
   return (
     <ul>


### PR DESCRIPTION
## 📘 Study PR

- Branch: feature/m5
- Subject:  검색창 최적화 - Debounce vs Throttle 적용 및 비교

<br>

## 📌 Notes
### 1. Debounce 적용
```jsx
useEffect(() => {
  // 검색어가 없으면 전체 데이터 표시
  if (!param) {
    setFilteredData(data);
    return;
  }

  // 한글 초성/중성 검색을 위한 정규식 생성
  const reg = getRegExp(param);

  const debounceTimer = setTimeout(() => {
    const newFilteredData = data.filter((el) => el.name.match(reg));
    setFilteredData(newFilteredData);
  }, 1000);

  // cleanup 함수: 컴포넌트 언마운트 또는 param 변경 시 실행
  return () => clearTimeout(debounceTimer);
}, [param]);
```
- 검색어 입력 시 Debounce 적용 (입력 멈춘 뒤 1초 후 결과 필터링)
- 입력이 멈추고 1초 뒤에만 검색 실행 → 불필요한 호출 최소화
- setTimeout으로 실행을 1초 지연시키고, clearTimeout으로 이전 타이머를 취소 → 빠른 입력 동안은 실행되지 않고, 입력이 멈춘 뒤 한 번만 실행됨

### 2. Throttle 적용
```jsx
useEffect(() => {
  // 검색어가 없으면 전체 데이터 표시
  if (!param) {
    setFilteredData(data);
    return;
  }

  // 한글 초성/중성 검색을 위한 정규식 생성
  const reg = getRegExp(param);

  // 현재 시각
  const now = Date.now();

  // 마지막 실행으로부터 경과한 시간
  const timeSinceLastExecution = now - lastExecutedTime.current;

  // 검색 실행 함수
  const executeSearch = () => {
    const newFilteredData = data.filter((el) => el.name.match(reg));
    setFilteredData(newFilteredData);
    lastExecutedTime.current = Date.now(); // 실행 시각 업데이트
  };

  // Throttle 로직
  if (timeSinceLastExecution >= 1000) {
    // Case 1: 마지막 실행으로부터 1초 이상 지났으면 즉시 실행
    executeSearch();
  } else {
    // Case 2: 1초가 안 지났으면 남은 시간만큼 대기 후 실행

    // 기존에 예약된 타이머가 있다면 취소 (최신 입력만 반영하기 위해)
    if (throttleTimer.current) {
      clearTimeout(throttleTimer.current);
    }

    // 아직 남아있는 시간 계산 (1초 - 경과 시간)
    const remainingTime = 1000 - timeSinceLastExecution;

    // 남은 시간이 지나면 실행 예약
    throttleTimer.current = setTimeout(() => {
      executeSearch();
      throttleTimer.current = null; // 타이머 초기화
    }, remainingTime);
  }
  // Cleanup: 다음 useEffect 실행 전 or 컴포넌트 언마운트 시 타이머 정리
  return () => {
    if (throttleTimer.current) {
      clearTimeout(throttleTimer.current);
    }
  };
}, [param]); // param이 바뀔 때마다 이 로직이 실행됨
```
- 검색어 입력 시 Throttle 적용 (1초에 최대 1번만 실행)
- 빠른 입력 중에도 주기적으로 결과를 업데이트 → 꾸준한 반응성 유지
- 마지막 실행 시각(lastExecutedTime)과 현재 시각 차이를 계산 → 1초 이상이면 즉시 실행, 아니면 남은 시간 후 실행 예약. 입력이 계속 들어와도 “최대 1초에 한 번만” 실행되도록 제한됨

## 비교
구분 | Debounce | Throttle
-- | -- | --
실행 시점 | 마지막 입력 후 delay 지난 시점 | 일정 주기마다 최대 1회
장점 | 불필요 호출 최소화 | 꾸준한 반응성 유지
단점 | 실행이 늦어질 수 있음 | 주기적 호출이 남음
예시 | 검색 자동완성, 폼 입력 검증 | 스크롤, 리사이즈 이벤트


<br>

## 📚 Reference (선택)


---

💡이 브랜치는 검색창 최적화 학습을 위해 Debounce와 Throttle을 직접 구현·비교한 내용을 정리했습니다.